### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/sthcoders/648595ec-6940-4092-9d0a-8f6c6e53cae1/e796337f-279a-450d-b0a5-07019476ad31/_apis/work/boardbadge/79b31d79-105d-445c-bac6-b1645ef23d71)](https://dev.azure.com/sthcoders/648595ec-6940-4092-9d0a-8f6c6e53cae1/_boards/board/t/e796337f-279a-450d-b0a5-07019476ad31/Microsoft.RequirementCategory)
 # sth-prod
 
 ## Table of Contents


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sthcoders/648595ec-6940-4092-9d0a-8f6c6e53cae1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.